### PR TITLE
Packager dss.py updated

### DIFF
--- a/async_packager/packager/dss.py
+++ b/async_packager/packager/dss.py
@@ -39,7 +39,9 @@ def write_contents_to_dssfile(outfile, watershed, items, callback):
             data = ds.GetRasterBand(1).ReadAsArray().astype(np.dtype('float32'))
 
             # Projection
-            proj = ds.GetProjection()
+            # proj = ds.GetProjection()
+            proj = '"PROJCS[\"USA_Contiguous_Albers_Equal_Area_Conic_USGS_version\",GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Albers\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",-96.0],PARAMETER[\"Standard_Parallel_1\",29.5],PARAMETER[\"Standard_Parallel_2\",45.5],PARAMETER[\"Latitude_Of_Origin\",23.0],UNIT[\"Meter\",1.0]]"'
+
             # Affine Transform
             geo_transform = ds.GetGeoTransform()
             affine_transform = Affine.from_gdal(*geo_transform)
@@ -49,12 +51,14 @@ def write_contents_to_dssfile(outfile, watershed, items, callback):
             grid_info.update([
                 ('grid_type','shg-time'),
                 ('grid_crs', proj),
-                ('grid_transform', affine_transform),
+                ('grid_transform', Affine(cellsize,0,0,0,0,0)),
                 ('data_type', item['dss_datatype'].lower()),
                 ('data_units', item['dss_unit'].lower()),
+                ('opt_crs_name', 'AlbersInfo'),
+                ('opt_is_interval', True),
+                ('opt_time_stamped', True),
                 ('opt_lower_left_x', watershed['bbox'][0] / cellsize),
                 ('opt_lower_left_y', watershed['bbox'][1] / cellsize),
-                ('opt_time_stamped',False)
             ])
 
             fid.put_grid(
@@ -62,5 +66,5 @@ def write_contents_to_dssfile(outfile, watershed, items, callback):
                 data,
                 grid_info
             )
-        
+
     return os.path.abspath(outfile)

--- a/async_packager/packager/dss.py
+++ b/async_packager/packager/dss.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.ma as ma
 from osgeo import gdal
 from affine import Affine
+from collections import namedtuple
 
 import config as CONFIG
 
@@ -10,25 +11,32 @@ from pydsstools.heclib.dss.HecDss import Open
 from pydsstools.heclib.utils import gridInfo
 
 
-def write_contents_to_dssfile(outfile, watershed, items, callback):
+def write_contents_to_dssfile(outfile, watershed, items, callback, cellsize=2000, dst_srs="EPSG:5070"):
 
-    cellsize = 2000
+    HEC_WKT = '"PROJCS[\"USA_Contiguous_Albers_Equal_Area_Conic_USGS_version\",GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Albers\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",-96.0],PARAMETER[\"Standard_Parallel_1\",29.5],PARAMETER[\"Standard_Parallel_2\",45.5],PARAMETER[\"Latitude_Of_Origin\",23.0],UNIT[\"Meter\",1.0]]"'
 
     with Open(outfile) as fid:
 
         item_length = len(items)
+
+        Watershed = namedtuple("Watershed", watershed)
+        _watershed = Watershed(**watershed)
 
         for idx, item in enumerate(items):
             # Update progress at predefined interval
             if idx % CONFIG.PACKAGER_UPDATE_INTERVAL == 0 or idx == item_length-1:
                 callback(idx)
 
+            # Named tuple for the watershed's contents
+            WatershedContent = namedtuple("WatershedContent", item)
+            content = WatershedContent(**item)
+
             ds = gdal.Warp(
                 '/vsimem/projected.tif',
-                f'/vsis3_streaming/{item["bucket"]}/{item["key"]}',
-                dstSRS='EPSG:5070',
+                f'/vsis3_streaming/{content.bucket}/{content.key}',
+                dstSRS=dst_srs,
                 outputType=gdal.GDT_Float64,
-                outputBounds=watershed["bbox"],
+                outputBounds=_watershed.bbox,
                 resampleAlg="bilinear",
                 targetAlignedPixels=True,
                 xRes=cellsize,
@@ -39,30 +47,30 @@ def write_contents_to_dssfile(outfile, watershed, items, callback):
             data = ds.GetRasterBand(1).ReadAsArray().astype(np.dtype('float32'))
 
             # Projection
-            # proj = ds.GetProjection()
-            proj = '"PROJCS[\"USA_Contiguous_Albers_Equal_Area_Conic_USGS_version\",GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Albers\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",-96.0],PARAMETER[\"Standard_Parallel_1\",29.5],PARAMETER[\"Standard_Parallel_2\",45.5],PARAMETER[\"Latitude_Of_Origin\",23.0],UNIT[\"Meter\",1.0]]"'
+            proj = HEC_WKT if ("5070" in dst_srs) else ds.GetProjection()
 
             # Affine Transform
             geo_transform = ds.GetGeoTransform()
-            affine_transform = Affine.from_gdal(*geo_transform)
+            affine_transform = Affine(cellsize,0,0,0,0,0) if ("5070" in dst_srs) \
+                else Affine.from_gdal(*geo_transform)
 
             # Create HEC GridInfo Object
             grid_info = gridInfo()
             grid_info.update([
                 ('grid_type','shg-time'),
                 ('grid_crs', proj),
-                ('grid_transform', Affine(cellsize,0,0,0,0,0)),
-                ('data_type', item['dss_datatype'].lower()),
-                ('data_units', item['dss_unit'].lower()),
+                ('grid_transform', affine_transform),
+                ('data_type', content.dss_datatype.lower()),
+                ('data_units', content.dss_unit.lower()),
                 ('opt_crs_name', 'AlbersInfo'),
                 ('opt_is_interval', True),
                 ('opt_time_stamped', True),
-                ('opt_lower_left_x', watershed['bbox'][0] / cellsize),
-                ('opt_lower_left_y', watershed['bbox'][1] / cellsize),
+                ('opt_lower_left_x', _watershed.bbox[0] / cellsize),
+                ('opt_lower_left_y', _watershed.bbox[1] / cellsize),
             ])
 
             fid.put_grid(
-                f'/SHG/{watershed["name"]}/{item["dss_cpart"]}/{item["dss_dpart"]}/{item["dss_epart"]}/{item["dss_fpart"]}/',
+                f'/SHG/{_watershed.name}/{content.dss_cpart}/{content.dss_dpart}/{content.dss_epart}/{content.dss_fpart}/',
                 data,
                 grid_info
             )


### PR DESCRIPTION
Closes USACE/cumulus#35

Projection WKT set to HEC's WKT from AlbersInfo Java class.
The pydsstools package uses a grid transform defined with Affine
and that grid transform definition is set to zeros except postion
zero (0) as the cellsize.  This, along with a mode to grid.pyx,
sets the XY Coord of grid cell to zero; what CWMS CAVI 3.2.1 requires.