### PR TITLE
MediaServer endpoint to serve DSS Downloads

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS builder
+FROM golang:1.15-alpine AS builder
 # Install Git
 RUN apk update && apk add --no-cache git
 # Copy In Source Code

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -24,6 +26,24 @@ type Config struct {
 	AsyncEngineStatisticsTarget  string `envconfig:"ASYNC_ENGINE_STATISTICS_TARGET"`
 	StaticHost                   string `envconfig:"STATIC_HOST"`
 	ApplicationKey               string `envconfig:"APPLICATION_KEY"`
+	AWSS3Endpoint                string `envconfig:"AWS_S3_ENDPOINT"`
+	AWSS3Region                  string `envconfig:"AWS_S3_REGION"`
+	AWSS3DisableSSL              bool   `envconfig:"AWS_S3_DISABLE_SSL"`
+	AWSS3ForcePathStyle          bool   `envconfig:"AWS_S3_FORCE_PATH_STYLE"`
+	AWSS3Bucket                  string `envconfig:"AWS_S3_BUCKET"`
+}
+
+func (cfg Config) AWSConfig() aws.Config {
+
+	a := aws.NewConfig().WithRegion(cfg.AWSS3Region)
+
+	// Used for "minio" during development
+	a.WithDisableSSL(cfg.AWSS3DisableSSL)
+	a.WithS3ForcePathStyle(cfg.AWSS3ForcePathStyle)
+	if cfg.AWSS3Endpoint != "" {
+		a.WithEndpoint(cfg.AWSS3Endpoint)
+	}
+	return *a
 }
 
 // GetConfig returns environment variable config

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/USACE/go-simple-asyncer v0.0.0-20201015223104-446ae10887a8
 	github.com/apex/gateway v1.1.2
+	github.com/aws/aws-sdk-go v1.35.7
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/uuid v1.1.2

--- a/api/handlers/media.go
+++ b/api/handlers/media.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/labstack/echo/v4"
+)
+
+func cleanFilepath(rawPath string) (string, error) {
+	p, err := url.PathUnescape(rawPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean("/" + p), nil
+}
+
+func ServeMedia(awsCfg *aws.Config, bucket *string) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		path, err := cleanFilepath(c.Request().RequestURI)
+		if err != nil {
+			return c.String(http.StatusBadRequest, err.Error())
+		}
+
+		_client := s3.New(session.New(awsCfg))
+		output, err := _client.GetObject(&s3.GetObjectInput{Bucket: bucket, Key: aws.String(path)})
+		if err != nil {
+			return c.String(500, err.Error())
+		}
+
+		buff, buffErr := ioutil.ReadAll(output.Body)
+		if buffErr != nil {
+			return c.String(500, err.Error())
+		}
+
+		reader := bytes.NewReader(buff)
+
+		c.Response().Header().Set(echo.HeaderContentDisposition, "attachment")
+		return c.Stream(http.StatusOK, "application/octet-stream", reader)
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -55,6 +55,9 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	// AWS Config
+	awsCfg := cfg.AWSConfig()
+
 	// Database
 	db := Connection(cfg)
 
@@ -116,6 +119,8 @@ func main() {
 	public.GET("/downloads/:id/packager_request", handlers.GetDownloadPackagerRequest(db))
 	public.POST("/downloads", handlers.CreateDownload(db))
 	public.PUT("/downloads/:id", handlers.UpdateDownload(db))
+	// Serve Download Files
+	public.GET("/cumulus/download/dss/*", handlers.ServeMedia(&awsCfg, &cfg.AWSS3Bucket))
 
 	// Restricted Routes (JWT or Key)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,8 +112,9 @@ services:
     build:
       context: api
     environment:
-      - AWS_ACCESS_KEY_ID=x
-      - AWS_SECRET_ACCESS_KEY=x
+      - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+      - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      - AWS_DEFAULT_REGION=us-east-1
       - AWS_REGION=us-east-1
       - CUMULUS_APPLICATION_KEY=appkey
       - CUMULUS_AUTH_DISABLED=FALSE
@@ -130,19 +131,15 @@ services:
       - CUMULUS_ASYNC_ENGINE_PACKAGER_TARGET=local/http://localhost:9324/queue/cumulus-packager
       - CUMULUS_ASYNC_ENGINE_STATISTICS=AWSSQS
       - CUMULUS_ASYNC_ENGINE_STATISTICS_TARGET=local/http://localhost:9324/queue/cumulus-statistics
-      - CUMULUS_STATIC_HOST=https://api.rsgis.dev
+      - CUMULUS_STATIC_HOST=http://localhost
+      - CUMULUS_AWS_S3_REGION=us-east-1
+      - CUMULUS_AWS_S3_BUCKET=cwbi-data-develop
+      - CUMULUS_AWS_S3_ENDPOINT=http://minio:9000
+      - CUMULUS_AWS_S3_DISABLE_SSL=True
+      - CUMULUS_AWS_S3_FORCE_PATH_STYLE=True
     ports:
       - "80:80"
     restart: always
-  nginx:
-    image: nginx
-    ports: 
-        - "8080:80"
-    build: 
-      context: async_packager
-      dockerfile: Dockerfile-nginx
-    volumes:
-      - ./data:/usr/share/nginx/html/cumulus/download/dss
   pgadmin:
     image: dpage/pgadmin4
     environment:


### PR DESCRIPTION
- MediaServer endpoint to serve DSS Downloads
- API Go Version 1.14 --> 1.15
- Remove Nginx from Docker Compose

closes USACE/cumulus#99