### PR TITLE
Bugfix/v download request increase fct lookback time

### DIFF
--- a/database/sql/05-downloads.sql
+++ b/database/sql/05-downloads.sql
@@ -134,7 +134,7 @@ CREATE OR REPLACE VIEW v_download AS (
                 -- observed data will use the file datetime  
 			  WHERE (date_part('year', f.version) = '1111' AND f.datetime >= dp.datetime_start AND f.datetime <= dp.datetime_end)
                 -- forecast data with an end date < now (looking at forecasts in the past)
-			    OR (dp.datetime_end < now() AND date_part('year', f.version) != '1111' AND f.version between dp.datetime_end - interval '12 hours' and dp.datetime_end)
+			    OR (dp.datetime_end < now() AND date_part('year', f.version) != '1111' AND f.version between dp.datetime_end - interval '24 hours' and dp.datetime_end)
 			    -- forecast data with an end date >= now (looking at current latest forecasts)
 			    OR (dp.datetime_end >= now() AND date_part('year', f.version) != '1111' AND f.version between now() - interval '12 hours' and now())
                 ORDER BY f.product_id, f.version, f.datetime) dss;


### PR DESCRIPTION
in some cases, when a past forecast product that is only issued every 24 hours is requested, it may result in 0 productfiles.  The 12 hour lookback from the requested datetime_end is not long enough.  Changing lookback in view from 12 to 24 hours for forecast products only.  The sql code in models/download.go will still restrict the processing to the last two forecast sets.