### PR TITLE
set 24 hour lookback on requested start to catch last forecast

### DIFF
--- a/api/models/download.go
+++ b/api/models/download.go
@@ -152,7 +152,7 @@ func GetDownloadPackagerRequest(db *pgxpool.Pool, downloadID *uuid.UUID) (*Packa
 					from download_products d
 					where d.download_id = dp.download_id 
 					and d.product_id = dp.product_id 
-					and d.forecast_version between dp.datetime_start and dp.datetime_end 
+					and d.forecast_version between dp.datetime_start - interval '24 hours' and dp.datetime_end 
 					order by d.forecast_version desc limit 2)
 				UNION
 				select 


### PR DESCRIPTION
When a user leaves or sets the datetime_start to 'now' (and datetime_end in the future), no results will return for the latest foreceast.  This is because the forecast (set) version's datetime is being compared and not the actual productfile's datetime.  This lookback on the datetime_start of 24 hours will allow a result.  It will still filter to the last two forecast version sets (if more than one) to reduce overlapped grids and processing time by the packager.