### PR TITLE
Added dstNoData to writing to dssfile

### DIFF
--- a/async_packager/packager/dss.py
+++ b/async_packager/packager/dss.py
@@ -31,17 +31,22 @@ def write_contents_to_dssfile(outfile, watershed, items, callback, cellsize=2000
             WatershedContent = namedtuple("WatershedContent", item)
             content = WatershedContent(**item)
 
+            kwargs = {
+                'dstSRS': dst_srs,
+                'outputType': gdal.GDT_Float64,
+                'outputBounds': _watershed.bbox,
+                'resampleAlg': 'bilinear',
+                'targetAlignedPixels': True,
+                'xRes': cellsize,
+                'yRes': cellsize,
+                'dstNodata': 0,
+            }
             try:
+                
                 ds = gdal.Warp(
                     '/vsimem/projected.tif',
                     f'/vsis3_streaming/{content.bucket}/{content.key}',
-                    dstSRS=dst_srs,
-                    outputType=gdal.GDT_Float64,
-                    outputBounds=_watershed.bbox,
-                    resampleAlg="bilinear",
-                    targetAlignedPixels=True,
-                    xRes=cellsize,
-                    yRes=cellsize
+                    **kwargs
                 )
 
                 # Raw Cell Values as Array


### PR DESCRIPTION
Closes USACE/cumulus#131

Testing the packager does not allow for `-3.402823466e+38` as the `No Data Value` when processing DSS files.  A zero as a no data value will produce grid records while the above `MAX_FLOAT` will not.