### PR TITLE
Feature/krf refactor with migration

### DIFF
--- a/api/_sql/common/V1.4.1__product_ncrfc_mpe.sql
+++ b/api/_sql/common/V1.4.1__product_ncrfc_mpe.sql
@@ -1,0 +1,3 @@
+-- acquirable
+INSERT INTO acquirable (id, name, slug) VALUES
+    ('a5cef3c8-9063-413b-b8a7-15c55eff8048', 'ncrfc-mpe-01h', 'ncrfc-mpe-01h'),

--- a/async_geoprocess/cumulus/cumulus/processors/mbrfc-krf-qpe-01h.py
+++ b/async_geoprocess/cumulus/cumulus/processors/mbrfc-krf-qpe-01h.py
@@ -1,11 +1,12 @@
-from datetime import datetime, timezone
-from logging import log
 import os
-from uuid import uuid4
-from ..geoprocess.core.base import info, translate, create_overviews, warp
-from ..handyutils.core import change_final_file_extension, gunzip_file
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import List, OrderedDict
+from uuid import uuid4
+
+from ..geoprocess.core.base import create_overviews, info, translate, warp
+from ..handyutils.core import change_final_file_extension, gunzip_file
+
 
 @dataclass
 class Band():
@@ -63,8 +64,8 @@ def process(infile, outdir) -> List:
     meta_dict = band.metadata[""]
     meta = Metadata(**meta_dict)
 
-    # ref_time = datetime.fromtimestamp(int(meta.GRIB_REF_TIME.split(" ")[0]))
-    valid_time = datetime.fromtimestamp(int(meta.GRIB_VALID_TIME.split(" ")[0]))
+    # ref_time = datetime.fromtimestamp(int(meta.GRIB_REF_TIME))
+    valid_time = datetime.fromtimestamp(int(meta.GRIB_VALID_TIME), timezone.utc)
 
     # Extract Band; Convert to COG
 
@@ -82,7 +83,7 @@ def process(infile, outdir) -> List:
         {
             "filetype": ftype,
             "file": cog,
-            "datetime": valid_time.replace(tzinfo=timezone.utc).isoformat(), 
+            "datetime": valid_time.isoformat(), 
             "version": None
         }
     )


### PR DESCRIPTION
MBRFC KRF QPE 01h meta data change for GRIG times.  This refactor solves that datetime issue.

Also, included is a migration adding ncrfc-mpe-01h to the acquirables.