### PR TITLE
delete productfiles before product

### DIFF
--- a/sql/common/V1.9.0__ncrfc_delete_erroneous.sql
+++ b/sql/common/V1.9.0__ncrfc_delete_erroneous.sql
@@ -3,6 +3,9 @@
 
 -- NCRFC, Airtemp 1hr
 -- ncrfc-fmat-01h
+DELETE from productfile
+where product_id = '71644147-5910-4e65-9195-43c37fc6ddc6'
+
 DELETE FROM product
 WHERE id = '71644147-5910-4e65-9195-43c37fc6ddc6';
 
@@ -16,6 +19,9 @@ WHERE id = '28d16afe-2834-4d2c-9df2-fdf2c40e510f';
 
 -- -- MARFC, NBM Airtemp 3hr
 -- -- marfc-nbmt-03h
+DELETE from productfile
+where product_id = '4b556067-9610-42fc-a71d-0fa0fcbd8ea1'
+
 DELETE FROM product
 WHERE id = '4b556067-9610-42fc-a71d-0fa0fcbd8ea1';
 


### PR DESCRIPTION
resolve the following error during migration:

`SQL State : 23503
Error Code : 0
Message : ERROR: update or delete on table "product" violates foreign key constraint "productfile_product_id_fkey" on table "productfile"
Detail: Key (id)=(71644147-5910-4e65-9195-43c37fc6ddc6) is still referenced from table "productfile".
Location : /flyway/sql/common/V1.9.0__ncrfc_delete_erroneous.sql (/flyway/sql/common/V1.9.0__ncrfc_delete_erroneous.sql)
Line : 6
Statement : -- ncrfc surface airtemp forecast removed to correct product as realtime
-- child tables have ON DELETE CASCADE linked to product table
-- NCRFC, Airtemp 1hr
-- ncrfc-fmat-01h
DELETE FROM product
WHERE id = '71644147-5910-4e65-9195-43c37fc6ddc6'

Caused by: Migration V1.9.0__ncrfc_delete_erroneous.sql failed`
