### PR TITLE
Temporarily Support Anonymous Downloads

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -186,6 +186,7 @@ func main() {
 	// List Downloads
 	private.GET("/downloads", handlers.ListAdminDownloads(db), middleware.IsAdmin)
 	// Create Download (Anonymous)
+	public.POST("/deprecated/anonymous_downloads", handlers.CreateDownload(db, cfg), middleware.AttachAnonymousUserInfo) // deprecated
 	private.POST("/downloads", handlers.CreateDownload(db, cfg))
 	public.GET("/downloads/:download_id", handlers.GetDownload(db))
 	// Create Download (Authenticated)

--- a/api/middleware/audit.go
+++ b/api/middleware/audit.go
@@ -19,6 +19,18 @@ type UserInfo struct {
 	IsAdmin bool       `json:"is_admin"`
 }
 
+func AttachAnonymousUserInfo(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		anonUUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+		c.Set("userInfo", UserInfo{
+			Sub: &anonUUID,
+			Roles: []string{},
+			IsAdmin: false,
+		})
+		return next(c)
+	}
+}
+
 func AttachUserInfo(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		keyAuthSuccess, ok := c.Get("ApplicationKeyAuthSuccess").(bool)


### PR DESCRIPTION
Temporarily support anonymous downloads via endpoint POST /deprecated/anonymous_downloads