### PR TITLE
Feature/snodas corrections geoprocess (#302)

### DIFF
--- a/async_geoprocess/src/cumulus_geoproc/geoprocess/handler.py
+++ b/async_geoprocess/src/cumulus_geoproc/geoprocess/handler.py
@@ -90,6 +90,7 @@ def upload_notify(notices: list, bucket: str):
     for notice in notices:
         # try to upload and continue if it doesn't returning only
         # what was successfully uploaded
+        logger.debug(f"Upload Notice from Notices: {notice=}")
         try:
             # try to upload to S3
             file = notice["file"]
@@ -118,6 +119,7 @@ def upload_notify(notices: list, bucket: str):
         cumulus_api.endpoint = "productfiles"
         cumulus_api.query = {"key": APPLICATION_KEY}
 
+        logger.debug(f"Payload to POST: {payload}")
         resp = asyncio.run(cumulus_api.post_(cumulus_api.url, payload=payload))
 
         responses.append({"upload": resp})

--- a/async_geoprocess/src/cumulus_geoproc/processors/nohrsc-snodas-assimilated.py
+++ b/async_geoprocess/src/cumulus_geoproc/processors/nohrsc-snodas-assimilated.py
@@ -10,7 +10,7 @@ Need to uncompress that NetCDF file
 import os
 import re
 import tarfile
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pyplugs
 from cumulus_geoproc import logger, utils
@@ -77,7 +77,7 @@ def process(src: str, dst: str, acquirable: str = None):
                         crs = ncds.variables["crs"]
                         data_vals = data[:]
 
-                        valid_time = datetime.fromisoformat(data.stop_date)
+                        valid_time = datetime.fromisoformat(data.stop_date).replace(tzinfo=timezone.utc)
 
                         xmin, ymin, xmax, ymax = (
                             lon.min(),
@@ -132,12 +132,13 @@ def process(src: str, dst: str, acquirable: str = None):
                         # Append dictionary object to outfile list
                         outfile_list.append(
                             {
-                                "filetype": acquirable,
+                                "filetype": "nohrsc-snodas-swe-corrections",
                                 "file": tif,
                                 "datetime": valid_time.isoformat(),
                                 "version": None,
                             }
                         )
+                        logger.debug(f"Outfile Append: {outfile_list[-1]}")
                     break
 
     except (RuntimeError, KeyError, Exception) as ex:

--- a/async_geoprocess/src/cumulus_geoproc/utils/capi.py
+++ b/async_geoprocess/src/cumulus_geoproc/utils/capi.py
@@ -2,7 +2,6 @@
 """
 
 from collections import namedtuple
-from email.mime import base
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
@@ -62,6 +61,16 @@ class CumulusAPI:
             client = httpx.AsyncClient(http2=self.http2)
             headers = [(b"content-type", b"application/json")]
             resp = await client.post(url, headers=headers, json=payload)
+            if resp.status_code in (200, 201):
+                return resp.json()
+        except ConnectionError as ex:
+            logger.warning(ex)
+
+    async def put_(self, url, payload):
+        try:
+            client = httpx.AsyncClient(http2=self.http2)
+            headers = [(b"content-type", b"application/json")]
+            resp = await client.put(url, headers=headers, json=payload)
             if resp.status_code in (200, 201):
                 return resp.json()
         except ConnectionError as ex:

--- a/async_geoprocess/worker.py
+++ b/async_geoprocess/worker.py
@@ -147,7 +147,7 @@ def start_worker():
                     f"Attempt to notify {len(processed_)} processed product(s)"
                 )
                 resp = handler.upload_notify(notices=processed_, bucket=GeoCfg.bucket)
-                logger.debug(resp)
+                logger.debug(f"Upload notification response: {resp}")
             except Exception as ex:
                 logger.warning(
                     f"{type(ex).__name__} - {this} - {ex} - {traceback.format_exc()}"


### PR DESCRIPTION
* fix link again (#243)

* Develop (#265)

* Feature/geoprocess regression test (#254)

* re-enable acquirablefiles route as private

* update to remove hard coded host

* expose acquirablefile_id

* new regression test

* comment out command to keep container running

* re-enable code

* changed to prevent image cache of repo code

* add gitignore for output

* add output volume mount

* pipe stdout to file along with stdout

* update readme

* install as user when switching to limited user

* continue if golden file not found

* fix container source

* adjust s3_download_file function call

* remove comment

* Refactor/complete overhaul snodas (#259)

* WIP

* WIP: AWS_SQS_ENDPOIINT or AWS_S3_ENDPOINT important

* WIP: checking processors

* fix link again (#243)

* WIP: refactor processors; down to ndgd-ltia

* add script for quick config scanner

* local only: set georprocessor to depend on api

* used smaller gdal image, run as non-root

* WIP: refactor processors to more normalized

* WIP: processor tests and snodas refactor

* WIP: SNODAS refactor

* WIP: Snodas processor tested

* WIP: Test confirm SNODAS

* WIP: processor testing

* WIP: Refactored SNODAS processors

* WIP: removed original geoprocess

* WIP: updates from dev

* WIP: update processors Translate dataset

* WIP: removed old snodas code and directory

* WIP: snodas interpolation

* WIP: snodas interpolation testing

* LDM, Processors Update, and other changes

LDM processors moved back with other processors b/c the source
is decoupled from the processor.  All processors have
if __name__ == "__main__": for local testing.  Setup.cfg updated
snodas swe mask tif package_data b/c that was moved in the package.

* WIP: Testing LDM product processors

* WIP: checked and tested all LDM products

* Processors and docstring

Added HRRR idx file parser class.  Updated find_band() looking
for char in an attribute; requires additional attr to narrow findings.
hrrr-total-precip processor updated using find_band() or HrrrIdx
file parsing to deal with archived files without idx file.

* WIP: missed cbrfc-mpe update

* WIP: debug the beaver

* WIP: SNODAS interp datetime and base creation options

* Added overviews option and updated processors

* WIP: SNODAS Snow Melt (1044) not added to DB

* WIP: translate_w_overviews translate first and then build overviews

* WIP: fixed PRISM and translate with overviews fixes hrrr

* WIP: GA_Update added back to translate_w_overviews method

* WIP: translate to COG and testing processors

* Processors, setup, and dockerfile

- processors with http sources have been refactored and tested
- setup.cfg removed rasterio packages b/c not used
- Dockerfile osgeo/gdal version set to that in setup.cfg

* WIP: processors for LDM product sources updated

Co-authored-by: Adam Scarberry <46494851+adamscarberry@users.noreply.github.com>

* Removed some logger messages (#260)

* HRRR duration to 3600 (#261)

Co-authored-by: Jeff Gregory <jeffrey.s.gregory@me.com>

* Updated nbm-co, serfc-qpf and wpc-qpf product version (#262)

Co-authored-by: Jeff Gregory <jeffrey.s.gregory@me.com>

* Bugfix/naefs processor (#263)

* Updated nbm-co, serfc-qpf and wpc-qpf product version

* Refactor naefs processor

* Bugfix/snodas unmasked interp 2 co gs (#264)

* SNODAS processor and interp fix to COG

* Interpolate method only is max distance greater than 0

* interpolate package did not need subprocess import

* No interp for products 1038, 2072, and 3333

Co-authored-by: Adam Scarberry <46494851+adamscarberry@users.noreply.github.com>

* Update local repo

* ISO time format change for snodas correction

Co-authored-by: Adam Scarberry <46494851+adamscarberry@users.noreply.github.com>