### PR TITLE
handler.handle_message method

### DIFF
--- a/async_geoprocess/src/cumulus_geoproc/geoprocess/handler.py
+++ b/async_geoprocess/src/cumulus_geoproc/geoprocess/handler.py
@@ -56,7 +56,7 @@ def handle_message(geoprocess: str, GeoCfg: namedtuple, dst: str):
     elif geoprocess == "incoming-file-to-cogs":
         # process and get resulting dictionary object defining the new grid
         # add acquirable id to each object in the list
-        if src := boto.s3_download_file(bucket=GeoCfg.bucket, key=GeoCfg.key):
+        if src := boto.s3_download_file(bucket=GeoCfg.bucket, key=GeoCfg.key, dst=dst):
             proc_list = geo_proc(
                 plugin=GeoCfg.acquirable_slug,
                 src=src,


### PR DESCRIPTION
handler.handle_message method missing `dst=dst` to define `TemporaryDirectory()` and passing that through to the processor.  Currently, all temporary files/directories generated are done under `/tmp` leaving the OS to handle cleanup.