### PR TITLE
Download Manifest JSONB Column; Packager Updates; Unit Tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "AWS_SECRET_ACCESS_KEY": "x",
         "AWS_REGION": "us-east-1",
         "CUMULUS_APPLICATION_KEY": "appkey",
-        "CUMULUS_AUTH_ENVIRONMENT": "DEVELOP",
+        "CUMULUS_AUTH_ENVIRONMENT": "MOCK",
         "CUMULUS_DBUSER": "cumulus_user",
         "CUMULUS_DBPASS": "cumulus_pass",
         "CUMULUS_DBNAME": "postgres",
@@ -27,7 +27,7 @@
         "CUMULUS_ASYNC_ENGINE_PACKAGER_TARGET": "local/http://localhost:9324/queue/cumulus-packager",
         "CUMULUS_ASYNC_ENGINE_STATISTICS": "AWSSQS",
         "CUMULUS_ASYNC_ENGINE_STATISTICS_TARGET": "local/http://localhost:9324/queue/cumulus-statistics",
-        "CUMULUS_STATIC_HOST": "https://api.rsgis.dev"
+        "CUMULUS_STATIC_HOST": "http://localhost"
       },
       "args": []
     }

--- a/api/models/jsonb.go
+++ b/api/models/jsonb.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+)
+
+type JSONB map[string]interface{}
+
+func (p JSONB) Value() (driver.Value, error) {
+	return json.Marshal(p)
+}
+
+func (p *JSONB) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+	return json.Unmarshal(bytes, &p)
+}

--- a/async_packager/packager.py
+++ b/async_packager/packager.py
@@ -25,7 +25,7 @@ from cumulus_packager.configurations import (
     WRITE_TO_BUCKET,
 )
 from cumulus_packager.packager import handler
-from cumulus_packager.utils import capi, sizeof_fmt
+from cumulus_packager.utils import capi
 from cumulus_packager.utils.boto import s3_upload_file
 
 this = os.path.basename(__file__)
@@ -85,8 +85,8 @@ def handle_message(message):
                         # Manifest JSON
                         {
                             "size_bytes": os.path.getsize(package_file),
-                            "filecount": len(PayloadResp.contents)
-                        }
+                            "filecount": len(PayloadResp.contents),
+                        },
                     )
                 else:
                     handler.update_status(

--- a/async_packager/packager.py
+++ b/async_packager/packager.py
@@ -84,7 +84,7 @@ def handle_message(message):
                         PayloadResp.output_key,
                         # Manifest JSON
                         {
-                            "size": sizeof_fmt(os.path.getsize(package_file)),
+                            "size_bytes": os.path.getsize(package_file),
                             "filecount": len(PayloadResp.contents)
                         }
                     )

--- a/async_packager/packager.py
+++ b/async_packager/packager.py
@@ -25,7 +25,7 @@ from cumulus_packager.configurations import (
     WRITE_TO_BUCKET,
 )
 from cumulus_packager.packager import handler
-from cumulus_packager.utils import capi
+from cumulus_packager.utils import capi, sizeof_fmt
 from cumulus_packager.utils.boto import s3_upload_file
 
 this = os.path.basename(__file__)
@@ -82,7 +82,12 @@ def handle_message(message):
                         handler.PACKAGE_STATUS["SUCCESS"],
                         100,
                         PayloadResp.output_key,
-                    )  # Update Status of Download
+                        # Manifest JSON
+                        {
+                            "size": sizeof_fmt(os.path.getsize(package_file)),
+                            "filecount": len(PayloadResp.contents)
+                        }
+                    )
                 else:
                     handler.update_status(
                         download_id, handler.PACKAGE_STATUS["FAILED"], 51

--- a/async_packager/src/cumulus_packager/packager/handler.py
+++ b/async_packager/src/cumulus_packager/packager/handler.py
@@ -30,7 +30,7 @@ PACKAGE_STATUS = {
 }
 
 
-def update_status(id: str, status_id: str, progress: int, file: str = None):
+def update_status(id: str, status_id: str, progress: int, file: str = None, manifest: dict = None):
     """Update packager status to Cumulus API
 
     TODO: Check Documentation for accuracy
@@ -45,6 +45,8 @@ def update_status(id: str, status_id: str, progress: int, file: str = None):
         progress percentage as a decimal, by default 0
     file : str, optional
         S3 key to dss file, by default None
+    manifest : dict, optional
+        Dictionary with any information about the download
     """
     try:
         _json_payload = {
@@ -52,6 +54,7 @@ def update_status(id: str, status_id: str, progress: int, file: str = None):
             "status_id": status_id,
             "progress": int(progress),
             "file": file,
+            "manifest": manifest
         }
         r = requests.put(
             f"{CUMULUS_API_URL}/downloads/{id}",

--- a/async_packager/src/cumulus_packager/utils/__init__.py
+++ b/async_packager/src/cumulus_packager/utils/__init__.py
@@ -142,5 +142,31 @@ def decompress(src: str, dst: str = "/tmp", recursive: bool = False):
     return src
 
 
+def sizeof_fmt(num, suffix="B"):
+    """Return human-readable filesize string from number of bytes
+     
+    Source: https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
+
+    Parameters
+    ----------
+    num : int
+        number of bytes
+    suffix : str, optional
+        suffix to follow unit prefixes
+    
+    Returns
+    -------
+    str
+        Human-readable filesize string
+    """
+
+    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+
+    return f"{num:.1f}Yi{suffix}"
+
+
 if __name__ == "__main__":
     pass

--- a/async_packager/src/cumulus_packager/utils/__init__.py
+++ b/async_packager/src/cumulus_packager/utils/__init__.py
@@ -142,31 +142,5 @@ def decompress(src: str, dst: str = "/tmp", recursive: bool = False):
     return src
 
 
-def sizeof_fmt(num, suffix="B"):
-    """Return human-readable filesize string from number of bytes
-     
-    Source: https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
-
-    Parameters
-    ----------
-    num : int
-        number of bytes
-    suffix : str, optional
-        suffix to follow unit prefixes
-    
-    Returns
-    -------
-    str
-        Human-readable filesize string
-    """
-
-    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
-        if abs(num) < 1024.0:
-            return f"{num:3.1f}{unit}{suffix}"
-        num /= 1024.0
-
-    return f"{num:.1f}Yi{suffix}"
-
-
 if __name__ == "__main__":
     pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       - LOGGER_LEVEL=DEBUG
       - PACKAGER_UPDATE_INTERVAL=5
       # - CPL_VSIL_CURL_CHUNK_SIZE=20000000
-      - CPL_CURL_VERBOSE=1
+      # - CPL_CURL_VERBOSE=1
     # Volume to persist packager created file
     volumes:
       - ./_volumes/async_packager/output:/output:rw

--- a/sql/common/R__05_views_downloads.sql
+++ b/sql/common/R__05_views_downloads.sql
@@ -13,7 +13,8 @@ CREATE OR REPLACE VIEW v_download AS (
         w.name             AS watershed_name,
         s.name             AS status,
         dp.product_id      AS product_id,
-        f.abbreviation     AS format
+        f.abbreviation     AS format,
+        d.manifest         AS manifest
     FROM download d
         INNER JOIN download_format f ON f.id = d.download_format_id
         INNER JOIN download_status s ON d.status_id = s.id

--- a/sql/common/V2.06.00__download_manifest_column.sql
+++ b/sql/common/V2.06.00__download_manifest_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE download ADD COLUMN manifest jsonb;

--- a/tests/cumulus-regression-admin.postman_collection.json
+++ b/tests/cumulus-regression-admin.postman_collection.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "367844aa-aab4-4b76-bc82-00b9ac7e7dd8",
+		"_postman_id": "f64f8e49-3448-4b38-a099-49b8cbb95932",
 		"name": "cumulus-regression-admin",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20040250"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -1779,7 +1778,10 @@
 									"// status code is 201",
 									"pm.test(\"Status code is 201\", function () {",
 									"    pm.response.to.have.status(201);",
-									"});"
+									"});",
+									"",
+									"let jsonData = JSON.parse(responseBody);",
+									"pm.environment.set(\"dynamic_download_id\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -1804,6 +1806,47 @@
 							],
 							"path": [
 								"downloads"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateDownload",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// status code is 200",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"id\": \"{{dynamic_download_id}}\",\n    \"status_id\": \"3914f0bd-2290-42b1-bc24-41479b3a846f\",\n\t\"progress\": 100,\n\t\"file\": \"3e8db268-d9ca-47ec-ae93-21a3c2bcf0a1\",\n\t\"manifest\": {\n        \"size\": \"2.7 GiB\",\n        \"filecount\": 15\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/downloads/{{dynamic_download_id}}",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"downloads",
+								"{{dynamic_download_id}}"
 							]
 						}
 					},


### PR DESCRIPTION
closes USACE/cumulus#272

* Download Column `manifest` w/ fields `filecount` and `size`
* async_packager updated to write manifest field to api when download is 100% complete
* Ensures `format` (dss7 or tgz-cog) included in Download payload (bug was causing this to return `null` always).
* Postman test