### PR TITLE
Handle no data value as `None` in packager

### DIFF
--- a/async_packager/src/cumulus_packager/heclib/__init__.py
+++ b/async_packager/src/cumulus_packager/heclib/__init__.py
@@ -190,6 +190,10 @@ class zStructSpatialGrid(Structure):
         ("_data", c_void_p),
     ]
 
+    def __init__(self, *args, **kw):
+        self._nullValue = UNDEFINED
+        super().__init__(*args, **kw)
+
 
 def zwrite_record(
     dssfilename: str,

--- a/async_packager/src/cumulus_packager/writers/dss7.py
+++ b/async_packager/src/cumulus_packager/writers/dss7.py
@@ -142,13 +142,15 @@ def writer(
             # Read data into 1D array
             raster = warp_ds.GetRasterBand(1)
             nodata = raster.GetNoDataValue()
+
             data = raster.ReadAsArray(resample_alg=gdal.gdalconst.GRIORA_Bilinear)
             # Flip the dataset up/down because tif and dss have different origins
             data = numpy.flipud(data)
             data_flat = data.flatten()
 
             # GeoTransforma and lower X Y
-            xsize, ysize = warp_ds.RasterXSize, warp_ds.RasterYSize
+            xsize = warp_ds.RasterXSize
+            ysize = warp_ds.RasterYSize
             adfGeoTransform = warp_ds.GetGeoTransform()
             llx = int(adfGeoTransform[0] / adfGeoTransform[1])
             lly = int(


### PR DESCRIPTION
Addresses [cumulus #316](https://github.com/USACE/cumulus/issues/316)

- added initial value for `zStructSpatialGrid._nullValue`
- init value is C's FLT_MAX as negative (UNDEFINED_FLOAT in DSS)

This takes care of the undefined field in the zStructSpatialGrid structure.  The `dss7` packager writer does not need a code update because this initialization takes care of the undefined `noDataValue` in Grib/COG files' meta data.  End-to-end testing from Airflow to Cumulus UI downloads were tested with and without the code changes.

Products Tested:
- WPC QPF
- NBM Airtemp
- NBM QPF
- NDGD RTMA Airtemp