### PR TITLE
Packager Python config and Dockerfile

### DIFF
--- a/async_packager/Dockerfile
+++ b/async_packager/Dockerfile
@@ -1,31 +1,5 @@
-# Compile DSS and tiffdss
-FROM osgeo/gdal:ubuntu-small-3.5.0 as cbuilder
-
-RUN apt-get -y update && \
-    apt-get install -y git gcc gfortran python3-pip libffi-dev gdb zlib1g-dev make  && \
-    rm -rf /var/lib/apt/lists/*
-
-# clone the branches needed to compile
-RUN git clone --branch 7-IJ --single-branch https://github.com/HydrologicEngineeringCenter/hec-dss.git
-RUN git clone --branch stable --single-branch https://github.com/HydrologicEngineeringCenter/tiffdss.git
-
-# Compile heclib C
-WORKDIR /hec-dss/heclib/heclib_c
-RUN make
-
-# Compile heclib Fortran
-WORKDIR /hec-dss/heclib/heclib_f
-RUN make
-
-# Environment variable in the tiffdss makefile
-ENV HECFLAG="/hec-dss/heclib/heclib_c/Output/libhec_c.a /hec-dss/heclib/heclib_f/Output/libhec_f.a"
-
-# Compile tiffdss with heclib C, heclib Fortran and GDAL library in /usr/lib
-WORKDIR /tiffdss/src
-RUN make libtiffdss.so
-
 # Packager
-FROM osgeo/gdal:ubuntu-small-3.5.0 as packager
+FROM osgeo/gdal:ubuntu-small-3.6.1
 
 # force stdout and stderr to be unbuffered setting to non-empty
 ENV PYTHONUNBUFFERED=1
@@ -34,9 +8,12 @@ ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
 
 ENV PACKAGE=async_packager
 
-# update, install and clean up
+ENV TIFFDSS_VERSION=v0.1.1
+ENV TIFFDSS=tiffdss_ubuntu-latest
+
+# update and install other dependencies
 RUN apt-get -y update && \
-    apt-get install -y python3-pip && \
+    apt-get install -y python3-pip curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /app/${PACKAGE}
@@ -45,13 +22,16 @@ WORKDIR /app/${PACKAGE}
 
 COPY . .
 
-# pip install/upgrade requirements before the cumulus package
-# sphinx used to generate documentation from docstrings
+# pip install/upgrade
 RUN python3 -m pip install --upgrade pip wheel setuptools && \
-    python3 -m pip install /app/${PACKAGE}/ Sphinx sphinx_rtd_theme
+    python3 -m pip install /app/${PACKAGE}/
 
-# copy over the libtiffdss.so
-COPY --from=cbuilder --chown=root:root /tiffdss/src/libtiffdss.so /usr/lib/
+# get libtiffdss.so
+RUN curl -L https://github.com/HydrologicEngineeringCenter/tiffdss/releases/download/${TIFFDSS_VERSION}/${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz \
+    --output ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz && \
+    tar -zxvf ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz && \
+    mv libtiffdss.so /usr/lib/ &&\
+    rm -f ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz tiffdss *.o
 
 RUN useradd appuser && \
     mkdir -p -m 775 docs && \

--- a/async_packager/Dockerfile
+++ b/async_packager/Dockerfile
@@ -1,5 +1,5 @@
 # Packager
-FROM osgeo/gdal:ubuntu-small-3.6.1
+FROM osgeo/gdal:ubuntu-small-3.5.3
 
 # force stdout and stderr to be unbuffered setting to non-empty
 ENV PYTHONUNBUFFERED=1
@@ -8,7 +8,7 @@ ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
 
 ENV PACKAGE=async_packager
 
-ENV TIFFDSS_VERSION=v0.1.1
+ENV TIFFDSS_VERSION=v0.1.2
 ENV TIFFDSS=tiffdss_ubuntu-latest
 
 # update and install other dependencies
@@ -30,7 +30,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools && \
 RUN curl -L https://github.com/HydrologicEngineeringCenter/tiffdss/releases/download/${TIFFDSS_VERSION}/${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz \
     --output ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz && \
     tar -zxvf ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz && \
-    mv libtiffdss.so /usr/lib/ &&\
+    mv libtiffdss.so /usr/lib/ && \
     rm -f ${TIFFDSS}_${TIFFDSS_VERSION}.tar.gz tiffdss *.o
 
 RUN useradd appuser && \

--- a/async_packager/setup.cfg
+++ b/async_packager/setup.cfg
@@ -27,8 +27,7 @@ install_requires =
     pyplugs<=0.4.0
     netCDF4<=1.5.8
     requests<=2.28.0
-    GDAL<=3.5.0
-    gdal-utils<=3.5.0.0
+    gdal-utils>=3.5.0.0
     psycopg2-binary<=2.9.3
 include_package_data = True
 


### PR DESCRIPTION
- Python setup config mod removing GDAL<=3.5 requirement
- Slight refactor Dockerfile to use `tiffdss` C library release

The Python package setup.cfg file defined the GDAL version was to be less than or equal to version 3.5.0; therefore, restricting version 3.6.  That requirement has been removed to allow the base Docker image to define the GDAL version.

The Packager Dockerfile originally cloned HEC-DSS, Tiffdss, and compiled the C library for tiffdss (libtiffdss.so) that is used in the DSS7 packager to write records from GeoTiff to DSS7.  The Tiffdss GitHub repo now provides the compiled shared object in a release eliminating the need for the packager to compile on build.