### PR TITLE
Bugfix/326,332 packager download failing (#400)

### DIFF
--- a/async_geoprocess/Dockerfile
+++ b/async_geoprocess/Dockerfile
@@ -1,22 +1,22 @@
 FROM osgeo/gdal:ubuntu-full-3.5.1
 
-ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@main
-ENV PYTHONUNBUFFERED=1
-
 RUN apt-get update -y \
   && apt-get install -y python3-pip git \
   && rm -rf /var/lib/apt/lists/*
 
+RUN useradd appuser
+
+RUN mkdir -p /app/async_geoprocess
+
 # Cache buster
 RUN echo $(date +%s)
+
+ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@main
+ENV PYTHONUNBUFFERED=1
 
 # pip install/upgrade requirements before the cumulus package
 RUN python3 -m pip install --upgrade pip wheel setuptools \
   && python3 -m pip install $CUMULUS_GEOPROC_PIP_URL
-
-RUN useradd appuser
-
-RUN mkdir -p /app/async_geoprocess
 
 WORKDIR /app/async_geoprocess
 


### PR DESCRIPTION
* adjust dockerfile to prevent caching of geoproc installation

* fix packager not to fail entire download after single transformation fail

* change pass to continue