### PR TITLE
Security/414 patch async geoprocess

### DIFF
--- a/async_geoprocess/Dockerfile
+++ b/async_geoprocess/Dockerfile
@@ -1,20 +1,15 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.7.0
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.9.1
 
-# Note: 
-# 1) The apt-get upgrade below is due to the latest gdal:ubuntu-full-3.7.0
-#    base image being slightly out of date with patching.
-# 2) The individual lines below to install/upgrade was to get
-#    the packages to properly update and the docker vulnerabilities
-#    to be resolved.
-
-RUN apt-get update -y && apt-get upgrade -y \
-  && apt-get install -y python3-pip git \
-  && rm -rf /var/lib/apt/lists/* \
-  && python3 -m pip install --no-cache-dir --upgrade pip \
-  && python3 -m pip install --no-cache-dir --upgrade setuptools \
-  && python3 -m pip install --no-cache-dir --upgrade wheel \
-  && python3 -m pip install --no-cache-dir --upgrade pillow \
-  && python3 -m pip install --no-cache-dir --upgrade numpy
+RUN apt-get update -y && apt-get install -y \
+  git \
+  python3-pip \
+  python3-venv \
+  python3-dev \
+  postgresql-server-dev-all \
+  libhdf5-dev \
+  zlib1g-dev \
+  libnetcdf-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd appuser
 
@@ -23,13 +18,13 @@ RUN mkdir -p /app/async_geoprocess
 # Cache buster
 RUN echo $(date +%s)
 
-ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@main
+ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@gdal-3.9.1
 
 ENV PYTHONUNBUFFERED=1
 ENV GDAL_DATA=/usr/share/gdal
 
 # pip install the cumulus package
-RUN python3 -m pip install $CUMULUS_GEOPROC_PIP_URL
+RUN python3 -m pip install --break-system-packages $CUMULUS_GEOPROC_PIP_URL
 
 WORKDIR /app/async_geoprocess
 

--- a/async_geoprocess/Dockerfile
+++ b/async_geoprocess/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /app/async_geoprocess
 # Cache buster
 RUN echo $(date +%s)
 
-ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@gdal-3.9.1
+ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@main
 
 ENV PYTHONUNBUFFERED=1
 ENV GDAL_DATA=/usr/share/gdal


### PR DESCRIPTION
https://github.com/USACE/cumulus/issues/414

Merge after https://github.com/USACE/cumulus/issues/413 is completed to avoid multiple changing variables.

Note `ARG CUMULUS_GEOPROC_PIP_URL=git+https://github.com/USACE/cumulus-geoproc@gdal-3.9.1`

This will either need to be changed to `@main` when we merge that repo changes or perhaps we should try this new strategy to retain multiple versions for testing/upgrading.