### PR TITLE
Fix aprfc qpe units from mm to in

### DIFF
--- a/sql/common/V2.40.0__fix_aprfc_qpe_units.sql
+++ b/sql/common/V2.40.0__fix_aprfc_qpe_units.sql
@@ -1,0 +1,2 @@
+-- fix units in aprfc qpe from mm to in
+UPDATE product set unit_id = 'e245d39f-3209-4e58-bfb7-4eae94b3f8dd' WHERE label = 'aprfc-qpe-06h';


### PR DESCRIPTION
Checked totals in MMRS with DSS file for July 10 1200-1800 
![image](https://github.com/USACE/cumulus-api/assets/9432394/897756ab-03fa-4bee-93c0-50c2f71ad6e2)

QPF units appeared to be correctly coded as in
