### PR TITLE
Fix aprfc-qpf-06hr units Develop

### DIFF
--- a/sql/common/V2.45.0__NWP_update_Crooked_River_Watershed_extents.sql
+++ b/sql/common/V2.45.0__NWP_update_Crooked_River_Watershed_extents.sql
@@ -2,17 +2,19 @@
 -- xmin,ymax (top left), xmax ymax (top right), xmax ymin (bottom right), xmin ymin (bottom left), xmin ymax (top left again)
 
 --NWP - Crooked River
--- x_min  -6825762.86388243
--- x_max  -6100604.304031842
--- y_min  8258151.748351492
--- y_max  9081730.308212077
+--  x_min  -2080496.6819047283
+-- x_max  -1859467.910804729
+-- y_min  2517089.687076909
+-- y_max  2768116.934176909
+
+
 --Rounded:
--- x_min  -6825763
--- x_max  -6100605
--- y_min  8258152
--- y_max  9081731
+-- x_min  -2080497
+-- x_max  -1859468
+-- y_min 2517090
+-- y_max  2768117
 
 
 UPDATE watershed
-	SET geometry = ST_GeomFromText('POLYGON ((-7245681 5375027, -6825665 5375027, -6825665 5057730, -7245681 5057730, -7245681 5375027))',5070)
+	SET geometry = ST_GeomFromText('POLYGON ((-2080497 2768117, -1859468 2768117,-1859468 2517090, -2080497 2517090, -2080497 2768117))',5070)
 WHERE id = '070204a3-66d9-471c-bd6e-ab59ea0858bb';

--- a/sql/common/V2.45.0__NWP_update_Crooked_River_Watershed_extents.sql
+++ b/sql/common/V2.45.0__NWP_update_Crooked_River_Watershed_extents.sql
@@ -1,0 +1,18 @@
+-- Crooked River watershed NWP district
+-- xmin,ymax (top left), xmax ymax (top right), xmax ymin (bottom right), xmin ymin (bottom left), xmin ymax (top left again)
+
+--NWP - Crooked River
+-- x_min  -6825762.86388243
+-- x_max  -6100604.304031842
+-- y_min  8258151.748351492
+-- y_max  9081730.308212077
+--Rounded:
+-- x_min  -6825763
+-- x_max  -6100605
+-- y_min  8258152
+-- y_max  9081731
+
+
+UPDATE watershed
+	SET geometry = ST_GeomFromText('POLYGON ((-7245681 5375027, -6825665 5375027, -6825665 5057730, -7245681 5057730, -7245681 5375027))',5070)
+WHERE id = '070204a3-66d9-471c-bd6e-ab59ea0858bb';

--- a/sql/common/V2.45.0__fix_aprfc_qpf_units.sql
+++ b/sql/common/V2.45.0__fix_aprfc_qpf_units.sql
@@ -1,4 +1,0 @@
--- fix units in aprfc qpe from in to mm
-UPDATE product set unit_id = 'e245d39f-3209-4e58-bfb7-4eae94b3f8dd' WHERE slug = 'aprfc-qpf-06h';
-
-

--- a/sql/common/V2.45.0__fix_aprfc_qpf_units.sql
+++ b/sql/common/V2.45.0__fix_aprfc_qpf_units.sql
@@ -1,0 +1,4 @@
+-- fix units in aprfc qpe from in to mm
+UPDATE product set unit_id = 'e245d39f-3209-4e58-bfb7-4eae94b3f8dd' WHERE slug = 'aprfc-qpf-06h';
+
+


### PR DESCRIPTION
DSS units are now mm as expected in develop, but when comparing develop branch dss files from before fix, slight differences exist in the grids. This could be from from versioning?  Even stranger, downloads for the same timewindow produced different data temporal extents in dss files. If this is known or expected, it can be merged.
![image](https://github.com/user-attachments/assets/8e01a24f-201f-4b2c-8f27-4212b9ad58e9)

![image](https://github.com/user-attachments/assets/8a504e8b-4bf9-43ab-8b24-ec36e47214ba)

![image](https://github.com/user-attachments/assets/e85b501b-0b44-4d0b-b379-fdc427f1ddf0)
![image](https://github.com/user-attachments/assets/dc6f731f-9199-4609-8263-7799adf73e27)
