### PR TITLE
Mark 0 out of 0 reads as partial success

### DIFF
--- a/api/models/download.go
+++ b/api/models/download.go
@@ -68,6 +68,7 @@ type PackagerRequest struct {
 	Contents   []PackagerContentItem `json:"contents"`
 	Format     string                `json:"format"`
 	Extent     Extent                `json:"extent"`
+	ProductIDs []uuid.UUID           `json:"product_ids"`
 }
 
 // Extent is a name and a bounding box
@@ -210,7 +211,8 @@ func GetDownloadPackagerRequest(db *pgxpool.Pool, downloadID *uuid.UUID) (*Packa
 				   '/download_', d.id, '.', f.extension
 				) AS output_key,
 			   f.abbreviation AS format,
-			   COALESCE(c.contents, '[]'::jsonb) AS contents
+			   COALESCE(c.contents, '[]'::jsonb) AS contents,
+			   ARRAY(SELECT product_id FROM download_product WHERE download_id = $1) AS product_ids
 		FROM download d
 		INNER JOIN download_format f ON f.id = d.download_format_id
 		LEFT JOIN watershed w ON w.id = d.watershed_id

--- a/async_packager/packager.py
+++ b/async_packager/packager.py
@@ -76,11 +76,17 @@ def handle_message(message):
                 package_file = writer_result["file"]
                 product_stats = writer_result["product_stats"]
 
+                # Fill in products that had 0 files in contents
+                for pid in PayloadResp.product_ids:
+                    if str(pid) not in product_stats:
+                        product_stats[str(pid)] = {"expected": 0, "successful": 0}
+
                 # Determine status from per-product stats
                 total_expected = sum(ps["expected"] for ps in product_stats.values())
                 total_successful = sum(ps["successful"] for ps in product_stats.values())
+                all_products_have_data = all(ps["expected"] > 0 for ps in product_stats.values())
 
-                if total_successful == total_expected:
+                if total_successful == total_expected and all_products_have_data:
                     status_key = "SUCCESS"
                 else:
                     status_key = "PARTIAL_SUCCESS"


### PR DESCRIPTION
When reading empty data from a sub product, list as a partial success.